### PR TITLE
Feat/touchbass sync24

### DIFF
--- a/daisyduino/TouchBass/TouchBass.ino
+++ b/daisyduino/TouchBass/TouchBass.ino
@@ -51,12 +51,12 @@ static MValue verb_value;
 // Uncomment if you're planning using external sync (mono jack - with clock signal only)
 // #define EXTERNAL_SYNC
 // Uncomment if you're planning using external sync24 (with stereo jack - clock and start/stop signals)
-#define EXTERNAL_SYNC24
+#define EXTERNAL_SYNC_TRS
 
 #ifdef EXTERNAL_SYNC
 static const int clk_pin = D(S43);
 #endif
-#ifdef EXTERNAL_SYNC24
+#ifdef EXTERNAL_SYNC_TRS
 static const int clk_pin = D(S43);
 static const int clk_start_pin = D(S42);
 #endif
@@ -129,7 +129,7 @@ void setup() {
   #ifdef EXTERNAL_SYNC
   pinMode(clk_pin, INPUT);
   #endif
-  #ifdef EXTERNAL_SYNC24
+  #ifdef EXTERNAL_SYNC_TRS
   pinMode(clk_pin, INPUT);
   pinMode(clk_start_pin, INPUT_PULLUP);
   #endif
@@ -145,7 +145,7 @@ void loop() {
   #ifdef EXTERNAL_SYNC
   bass.ProcessClockIn(!digitalRead(clk_pin));
   #endif
-  #ifdef EXTERNAL_SYNC24
+  #ifdef EXTERNAL_SYNC_TRS
   bass.ProcessClockIn(!digitalRead(clk_pin));
   #endif
 
@@ -154,7 +154,7 @@ void loop() {
   is_to_touched = touch.IsTouched(10);
   is_ch_touched = touch.IsTouched(11);
 
-  #ifdef EXTERNAL_SYNC24
+  #ifdef EXTERNAL_SYNC_TRS
   auto arp_mode_value = arp_mode_switch.Value();
   bool ext_latch_on = digitalRead(clk_start_pin) == HIGH;
   if (ext_latch_on) {

--- a/daisyduino/TouchBass/TouchBass.ino
+++ b/daisyduino/TouchBass/TouchBass.ino
@@ -130,7 +130,7 @@ void setup() {
   pinMode(clk_pin, INPUT);
   #endif
   #ifdef EXTERNAL_SYNC24
-  pinMode(clk_pin, INPUT_PULLUP);
+  pinMode(clk_pin, INPUT);
   pinMode(clk_start_pin, INPUT_PULLUP);
   #endif
 
@@ -157,7 +157,6 @@ void loop() {
   #ifdef EXTERNAL_SYNC24
   auto arp_mode_value = arp_mode_switch.Value();
   bool ext_latch_on = digitalRead(clk_start_pin) == HIGH;
-  bool ext_clk_on = digitalRead(clk_pin) == LOW;
   if (ext_latch_on) {
     bass.SetArpOn(arp_mode_value > 0);
     bass.SetLatch(arp_mode_value > 1 || (arp_mode_value > 0 && ext_latch_on));

--- a/daisyduino/TouchBass/bass.h
+++ b/daisyduino/TouchBass/bass.h
@@ -45,7 +45,8 @@ public:
   _human_note_chance  { 0 },
   _scale_index        { 0 },
   _is_arp_on          { false },
-  _is_latched         { false }
+  _is_latched         { false },
+  _is_paused          { false }
   {
     _reverb_in.fill(0);
     _reverb_out.fill(0);
@@ -128,6 +129,28 @@ public:
       if (!_arp.HasNote()) Reset();
     }
     _is_latched = latch;
+  }
+
+  void Pause() {
+    if (_is_arp_on && !_is_paused) {
+      _is_paused = true;
+      _clock.Stop();
+    }
+  }
+
+  void Resume() {
+    if (_is_arp_on && _is_paused) {
+      _is_paused = false;
+      _clock.Run();
+    }
+  }
+
+  bool IsPaused() const {
+    return _is_paused;
+  }
+  
+  bool IsArpOn() const {
+    return _is_arp_on;
   }
 
   void ToggleMonoPoly() {
@@ -341,6 +364,7 @@ private:
   
   bool _is_arp_on;
   bool _is_latched;
+  bool _is_paused;
   std::array<bool, kNotesCount> _hold;
 };
 

--- a/daisyduino/TouchBass/bass.h
+++ b/daisyduino/TouchBass/bass.h
@@ -41,8 +41,8 @@ public:
   _tempo              { .45f },
   _env                { 0.f },
   _human_env_kof      { 0.f },
-  _human_env_chance   { 0.f },
-  _human_note_chance  { 0.f },
+  _human_env_chance   { 0 },
+  _human_note_chance  { 0 },
   _scale_index        { 0 },
   _is_arp_on          { false },
   _is_latched         { false }

--- a/daisyduino/TouchBass/mvalue.h
+++ b/daisyduino/TouchBass/mvalue.h
@@ -1,4 +1,4 @@
-#pragma once;
+#pragma once
 
 namespace synthux {
 

--- a/daisyduino/TouchBass/onoffon.h
+++ b/daisyduino/TouchBass/onoffon.h
@@ -1,4 +1,4 @@
-#pragma once;
+#pragma once
 
 namespace synthux {
 

--- a/daisyduino/TouchBass/simple-daisy-touch.h
+++ b/daisyduino/TouchBass/simple-daisy-touch.h
@@ -100,7 +100,9 @@ enum class Digital {
     S32 = D17,
     S33 = D18,
     S34 = D19,
-    S35 = D20
+    S35 = D20,
+    S42 = D27,
+    S43 = D28
 };
 
 template<class AP, class DP>


### PR DESCRIPTION
Added TRS (stereo jack) external sync support with both clock and start/stop signals
- Middle position: Pause/resume functionality with external start/stop signals
- Top position: Traditional latched arpeggiator behavior
- Both positions maintain proper note latching during sync state changes